### PR TITLE
feat: Implement offline sales and change collection

### DIFF
--- a/pos/views.py
+++ b/pos/views.py
@@ -288,7 +288,6 @@ def process_sale(request):
                 'cashier': f'{request.user.first_name} {request.user.last_name}',
                 'receipt_number': sale.receipt_number,
                 'total_amount': sale.total_amount,
-                'receipt_number':sale.receipt_number,
                 'tax': sale.tax,
                 'sub_total': sale.sub_total,
                 'received_amount': sale_data.get('received_amount'),

--- a/templates/finance/change_list.html
+++ b/templates/finance/change_list.html
@@ -242,47 +242,39 @@
                 amount:parseFloat(document.getElementById('id_amount').value)
             };
 
-            if (navigator.onLine) {
-                fetch('/pos/collect_change/', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCSRFToken()
-                    },
-                    body: JSON.stringify(data)
-                })
-                .then(response => response.json().then(data => ({
-                    status: response.status,
-                    data: data
-                })))
-                .then(res => {
-                    if (res.status === 200) {
-                        Swal.fire({
-                            icon: 'success',
-                            title: 'Success!',
-                            text: 'Change has been collected successfully.',
-                            confirmButtonText: 'OK'
-                        }).then(() => {
-                            location.reload();
-                        });
-                    } else {
-                        Swal.fire({
-                            icon: 'error',
-                            title: 'Error',
-                            text: res.data.message,
-                            confirmButtonText: 'OK'
-                        });
-                    }
-                })
-                .catch(error => {
+            fetch('/pos/collect_change/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCSRFToken()
+                },
+                body: JSON.stringify(data)
+            })
+            .then(response => response.json().then(data => ({
+                status: response.status,
+                data: data
+            })))
+            .then(res => {
+                if (res.status === 200) {
+                    Swal.fire({
+                        icon: 'success',
+                        title: 'Success!',
+                        text: 'Change has been collected successfully.',
+                        confirmButtonText: 'OK'
+                    }).then(() => {
+                        location.reload();
+                    });
+                } else {
                     Swal.fire({
                         icon: 'error',
-                        title: 'Request Failed',
-                        text: error.toString(),
+                        title: 'Error',
+                        text: res.data.message,
                         confirmButtonText: 'OK'
                     });
-                });
-            } else {
+                }
+            })
+            .catch(error => {
+                console.error('Fetch error:', error);
                 saveCollection(data).then(() => {
                     return navigator.serviceWorker.ready;
                 }).then(swRegistration => {
@@ -302,7 +294,7 @@
                         icon: "error"
                     });
                 });
-            }
+            });
         }
         
         function getCSRFToken() {

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1241,90 +1241,82 @@
             timestamp: new Date().toISOString()
         };
 
-        if (navigator.onLine) {
-            Swal.fire({
-                title: "Processing...",
-                text: "Please wait while the sale is being processed.",
-                allowOutsideClick: false,
-                allowEscapeKey: false,
-                didOpen: () => {
-                    Swal.showLoading();
-                }
-            });
+        Swal.fire({
+            title: "Processing...",
+            text: "Please wait while the sale is being processed.",
+            allowOutsideClick: false,
+            allowEscapeKey: false,
+            didOpen: () => {
+                Swal.showLoading();
+            }
+        });
 
-            fetch('{% url "pos:process_sale" %}', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken')
-                },
-                body: JSON.stringify(saleData)
-            })
-                .then(response => response.json())
-                .then(data => {
-                    Swal.close();
-                    if (data.success) {
-                        console.log('Sale processed successfully:', data);
-                        Swal.fire({
-                            title: "Success",
-                            text: "Processing Receipt",
-                            icon: "success"
-                        });
+        fetch('{% url "pos:process_sale" %}', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            body: JSON.stringify(saleData)
+        })
+            .then(response => response.json())
+            .then(data => {
+                Swal.close();
+                if (data.success) {
+                    console.log('Sale processed successfully:', data);
+                    Swal.fire({
+                        title: "Success",
+                        text: "Processing Receipt",
+                        icon: "success"
+                    });
 
-                        // Clear the cart and reset UI
-                        cart = [];
-                        updateOrderDetails();
-                        chargeModal.hide();
-                        clearChangeData()
-                        console.log('cleared')
+                    // Clear the cart and reset UI
+                    cart = [];
+                    updateOrderDetails();
+                    chargeModal.hide();
+                    clearChangeData()
+                    console.log('cleared')
 
-                        // Generate and print receipt
-                        const receiptContent = generateReceiptContent(data.data);
-                        printReceiptSilently(receiptContent);
+                    // Generate and print receipt
+                    const receiptContent = generateReceiptContent(data.data);
+                    printReceiptSilently(receiptContent);
 
-                    } else {
-                        Swal.fire({
-                            title: "Error",
-                            text: data.message,
-                            icon: "error"
-                        });
-                        chargeModal.hide();
-                    }
-                })
-                .catch(error => {
-                    Swal.close();
-                    console.error('Error:', error);
+                } else {
                     Swal.fire({
                         title: "Error",
-                        text: "An error occurred while processing the sale.",
+                        text: data.message,
+                        icon: "error"
+                    });
+                    chargeModal.hide();
+                }
+            })
+            .catch(error => {
+                Swal.close();
+                console.error('Fetch error:', error);
+                // Offline
+                saveSale(saleData).then(() => {
+                    return navigator.serviceWorker.ready;
+                }).then(swRegistration => {
+                    return swRegistration.sync.register('sync-pending-sales');
+                }).then(() => {
+                    Swal.fire({
+                        title: "Offline",
+                        text: "Sale saved locally. It will be synced when you're back online.",
+                        icon: "info"
+                    });
+                    cart = [];
+                    updateOrderDetails();
+                    chargeModal.hide();
+                    clearChangeData();
+                }).catch(error => {
+                    console.error('Error saving sale offline:', error);
+                    Swal.fire({
+                        title: "Error",
+                        text: "Could not save sale locally.",
                         icon: "error"
                     });
                 });
-        } else {
-            // Offline
-            saveSale(saleData).then(() => {
-                return navigator.serviceWorker.ready;
-            }).then(swRegistration => {
-                return swRegistration.sync.register('sync-pending-sales');
-            }).then(() => {
-                Swal.fire({
-                    title: "Offline",
-                    text: "Sale saved locally. It will be synced when you're back online.",
-                    icon: "info"
-                });
-                cart = [];
-                updateOrderDetails();
-                chargeModal.hide();
-                clearChangeData();
-            }).catch(error => {
-                console.error('Error saving sale offline:', error);
-                Swal.fire({
-                    title: "Error",
-                    text: "Could not save sale locally.",
-                    icon: "error"
-                });
             });
-        }
     }
 
     function generateReceiptContent(saleData) {


### PR DESCRIPTION
This commit implements a robust offline-first experience for the POS application. Sales and change collections can now be performed while the device is offline. The data is stored locally in IndexedDB and then synced to the server automatically when the connection is restored.

Key changes:
- **PWA Functionality:** Added a `manifest.json` and a service worker (`sw.js`) to make the application installable and to handle caching and background sync.
- **Offline Storage:** Implemented an IndexedDB wrapper (`db.js`) to store pending sales and change collections.
- **Robust Offline Detection:** The application now attempts to send requests to the server first. If the request fails, it falls back to saving the data locally. This is more reliable than using `navigator.onLine`.
- **Background Sync:** The service worker uses the Background Sync API to automatically sync offline data to the server when the connection is restored.
- **Backend Endpoints:**
  - Added `/pos/sync/` to process synced sales.
  - Added `/pos/sync-collections/` to process synced change collections.
  - Added `/pos/get-csrf-token/` to provide the CSRF token to the service worker for secure sync requests.
- **Code Refactoring:** Refactored the sale processing logic in `pos/views.py` into a reusable helper function to improve maintainability.